### PR TITLE
Update menuinst to 1.4.17

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,5 +1,0 @@
-%PYTHON% setup.py install
-if errorlevel 1 exit 1
-
-copy %SRC_DIR%\cwp.py %PREFIX%\
-if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-$PYTHON setup.py install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ test:
     - menuinst --help
 
 about:
-  home: https://github.com/ContinuumIO/menuinst
+  home: https://github.com/conda/menuinst
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.4.16" %}
-{% set sha256 = "c9ad6e225c2831656bac35b71ac1c8c3f82f08ba8da9718dfb3708485bbccc44" %}
+{% set version = "1.4.17" %}
+{% set sha256 = "143bc78efbbe9e34698df3d40f20576ccd9b62a199ebfff83cc5515049f70090" %}
 
 package:
   name: menuinst
@@ -7,12 +7,15 @@ package:
 
 source:
   fn: menuinst-{{ version }}.tar.gz
-  url: https://github.com/ContinuumIO/menuinst/archive/{{ version }}.tar.gz
+  url: https://github.com/conda/menuinst/archive/{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
-  number: 1
-  skip: true  # [not win]
+  number: 0
+  skip: True  # [not win]
+  script:
+    - {{ PYTHON }} -m pip install . -vv
+    - copy "%SRC_DIR%\\cwp.py" "%PREFIX%\\"
   entry_points:
     - menuinst = menuinst.main:main
   skip_compile_pyc:
@@ -20,34 +23,37 @@ build:
 
 requirements:
   build:
+    - {{ compiler('cxx') }}
+    - m2-patch  # [win]
+  host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
     - pywin32
 
 test:
-  commands:
-    - menuinst -h
-    - menuinst --version
   imports:
     - menuinst
-    - menuinst.winshortcut
-
+  requires:
+    - pip
   commands:
+    - pip check
     - menuinst --help
 
 about:
   home: https://github.com/ContinuumIO/menuinst
   license: BSD-3-Clause
+  license_family: BSD
   license_file: LICENSE.txt
-  summary: cross platform menu item installation
+  summary: cross platform install of menu items
   description: |
     This application is used by Conda to create shortcuts on a wide variety of
     systems.
-  doc_url: https://github.com/ContinuumIO/menuinst/wiki
-  doc_source_url: https://github.com/ContinuumIO/menuinst
-  dev_url: https://github.com/ContinuumIO/menuinst
+  dev_url: https://github.com/conda/menuinst
+  doc_url: https://github.com/conda/menuinst/wiki
 
 extra:
   recipe-maintainers:

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,4 +1,0 @@
-import menuinst
-
-print('menuinst.__version__: %s' % menuinst.__version__)
-assert menuinst.__version__ == '1.4.16'


### PR DESCRIPTION
Category:  miniconda | subcategory:  core | pkg_type:  python
Popularity:  658953 downloads -  menuinst  1.4.17  cross platform install of menu items  
Version change: bump version number from 1.4.16 to 1.4.17
Concourse builds correctly
  license: BSD-3-Clause
Bug Tracker: new open issues https://github.com/conda/menuinst/issues
Github releases:  https://github.com/conda/menuinst/releases
Upstream license: https://github.com/conda/menuinst/blob/master/LICENSE.txt
Upstream Changelog: https://github.com/conda/menuinst/blob/master/CHANGES.txt
Upstream setup.py:  https://github.com/conda/menuinst/blob/1.4.17/setup.py

The package menuinst is mentioned inside the packages:
conda | conda-standalone | console_shortcut  | powershell_shortcut | 

Actions:
1. Update dependencies: add build section
2. Add missing packages setuptools, wheel, and compiler cxx, and m2-patch
3. Add pip check
4. Add license_family
5. Update home, dev, doc urls
6. Build number changed: 0
7. Add  script:
```
    - {{ PYTHON }} -m pip install . -vv
    - copy "%SRC_DIR%\\cwp.py" "%PREFIX%\\"
```
8. Remove bld.bat and build.sh
9. Remove run_test.py (it's not useful, because assert only a version)
10. Update summary

Result:
- all-succeeded on concourse