### PR TITLE
Bump to 2.0.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.0.0" %}
+{% set version = "2.0.1" %}
 
 package:
   name: menuinst
@@ -7,7 +7,7 @@ package:
 source:
   fn: menuinst-{{ version }}.tar.gz
   url: https://github.com/conda/menuinst/archive/{{ version }}.tar.gz
-  sha256: 0ca844379c0d904cc1879f574c4d4320e89290e63e2f61e2996aebdd579d539e
+  sha256: 1ccd540ae5d3c348eef3761529a392184057fe9f21ea2dddb09a04b7ad9e9398
 
 build:
   number: 0


### PR DESCRIPTION
https://github.com/conda/menuinst/releases/tag/2.0.1