### PR TITLE
Rebuild for Python 3.12

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 1ccd540ae5d3c348eef3761529a392184057fe9f21ea2dddb09a04b7ad9e9398
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<38]
   script_env:
     - SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}


### PR DESCRIPTION
Necessary to roll out Python 3.12 support for conda (see https://github.com/conda/conda/pull/13073).