### PR TITLE
Update to v2.1.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.1.0" %}
+{% set version = "2.1.1" %}
 
 package:
   name: menuinst
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/conda/menuinst/archive/{{ version }}.tar.gz
-  sha256: 5570465822b11a63b87cf890ee061f588d1fe085bfafee7f5ba83d7f650daadb
+  sha256: 38e44a19a5d1fbe48c779b6a3a8d789224d2b3708e8270ecf8575d2d442ef2e7
 
 build:
   number: 0


### PR DESCRIPTION
menuinst 2.1.1

**Destination channel:** defaults

### Links

- [PKG-5060](https://anaconda.atlassian.net/browse/PKG-5060)
- [Upstream repository](https://github.com/conda/menuinst/)
- [Upstream changelog/diff](https://github.com/conda/menuinst/blob/main/CHANGELOG.md#211-2024-06-07)

### Explanation of changes:

- Update `menuinst` to v2.1.1

[PKG-5060]: https://anaconda.atlassian.net/browse/PKG-5060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ