### PR TITLE
Update to v2.1.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/conda/menuinst/archive/{{ version }}.tar.gz
-  sha256: 38e44a19a5d1fbe48c779b6a3a8d789224d2b3708e8270ecf8575d2d442ef2e7
+  sha256: 6515a4e33cec8462cdb389c1c301ddbe0679c992c02e3ea42eea25225063b0e9
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.1.1" %}
+{% set version = "2.1.2" %}
 
 package:
   name: menuinst


### PR DESCRIPTION
menuinst 2.1.2

**Destination channel:** defaults

### Links

- [PKG-5502](https://anaconda.atlassian.net/browse/PKG-5502) 
- [Upstream repository](https://github.com/conda/menuinst/)
- [Upstream changelog/diff](https://github.com/conda/menuinst/blob/main/CHANGELOG.md#212-2024-08-07)

### Explanation of changes:

- Update menuinst to v2.1.2

[PKG-5502]: https://anaconda.atlassian.net/browse/PKG-5502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ