### PR TITLE
Update menuinst to 2.3.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.3.0" %}
+{% set version = "2.3.1" %}
 
 package:
   name: menuinst
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/conda/menuinst/archive/{{ version }}.tar.gz
-  sha256: 4ddeb9479823fad9471ab9951b3d4bdca968ec4d1b579a2b74b7d4d1da135610
+  sha256: aaf1b141b78c3f193a968e01ea8ba8a9d25ab08c938f326437114fe108871280
 
 build:
   number: 0
@@ -46,7 +46,7 @@ test:
   requires:
     - pip
     - conda
-    - pydantic
+    - pydantic >=2
     - pytest
     - pytest-mock
   source_files:


### PR DESCRIPTION
menuinst 2.3.1

**Destination channel:** {defaults}

### Links

- [PKG-9008](https://anaconda.atlassian.net/browse/PKG-9008) 
- [Upstream repository](https://github.com/conda/menuinst)
- [Upstream changelog/diff](https://github.com/conda/menuinst/blob/main/CHANGELOG.md)

[PKG-9008]: https://anaconda.atlassian.net/browse/PKG-9008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ